### PR TITLE
Corrigido erro de exibição na seção "Execução de comandos"

### DIFF
--- a/lists/pt-br.md
+++ b/lists/pt-br.md
@@ -221,9 +221,9 @@ Este comando usa uma string para representar as permissões.
 |```&```|Executar em segunda plano (./script.sh &).|
 |```bash -xv```|Abre outro bash em formato debug (bash -xv script.sh).|
 |```;```|Executa um comando apos outro.|
-|```|```|Direciona a saida de um comando para outro.|
+|```\|```|Direciona a saida de um comando para outro.|
 |```&&```|Só executa o comando caso o comando anterior não retorne erro.|
-|```||```|Só executa o comando caso o comando anterior retorne erro.|
+|```\|\|```|Só executa o comando caso o comando anterior retorne erro.|
 
 ## Redirecionamento de entreada e saida 
 


### PR DESCRIPTION
Na seção "Execução de comandos" quando usado algo como " ```| " estava quebrando a formatação do arquivo.