### PR TITLE
Adds stat command to monitoring section

### DIFF
--- a/lists/en-us.md
+++ b/lists/en-us.md
@@ -140,14 +140,14 @@ This command uses a string that represents the permissions.
 |```ssh```|OpenSSH SSH client (remote access).|
 |```base64```|Base64 encodes / decodes the FILE, or standard input, to standard output.|
 
-## Monitoramento
+## Monitoring
 
 |Command|Description|
 |------|------|
 |```htop```|Displays processes running on the system.|
 |```vmstat```|Information about processes, memory, paging, block I / O, traps, disks and CPU activity.|
 |```free```|Watch and monitor system memory usage.|
-
+|```stat <file\|directory>```|Prints the given file or directory INode informations.|
 
 ## Packet manager (apt-get)
 

--- a/lists/pt-br.md
+++ b/lists/pt-br.md
@@ -309,6 +309,7 @@ Processos possuem permissões e prioridades, não é possivel matar os processos
 |```renice -6 <PID>```|Altera para -6 a prioridade do processo que foi passado.|
 |```renice -n 6 -u <usuário>```|Altera para 6 a prioridade de todos os processos do usuário que foi passado.|
 |```renice -n 6 -g <grupo>```|Altera para 6 a prioridade de todos os processos do grupo que foi passado.|    
+|```stat <arquivo\|diretório>```|Imprime as informações do INode do arquivo ou diretório.|    
 
 KILL
     


### PR DESCRIPTION
This Pull Request adds `stat` command to the Monitoring section in both languages: English and Portuguese. 
This command shows a given file INode information. Useful to understand how Linux Kernel perceives the file.

Please, let me know if there is anything missing on this PR. 